### PR TITLE
一个更好的注解使用的建议

### DIFF
--- a/spring-02-aop/src/main/java/com/linkedbear/spring/aop/c_joinpoint/service/impl/OrderServiceImpl.java
+++ b/spring-02-aop/src/main/java/com/linkedbear/spring/aop/c_joinpoint/service/impl/OrderServiceImpl.java
@@ -1,12 +1,12 @@
 package com.linkedbear.spring.aop.c_joinpoint.service.impl;
 
 import com.linkedbear.spring.aop.c_joinpoint.service.OrderService;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
 
-@Component
+@Service
 public class OrderServiceImpl implements OrderService {
     
     @Override


### PR DESCRIPTION
您好，我发现您的代码中的注释可能有一些小的改进。

服务层中的 Spring bean 应该使用 @service 而不是 @component 注解进行注解。
@service注解是@component在服务层的特化。 通过使用专门的注解，可以得到更优的效果。 首先，它们被视为 Spring bean，其次，您可以放置该层所需的特殊行为。

为了更好地理解和维护大型应用程序，@service 是更好的选择。